### PR TITLE
Typo fix in the file 1014-better-client-id-new.md

### DIFF
--- a/.changelog/v0.49.1/breaking-changes/1014-better-client-id-new.md
+++ b/.changelog/v0.49.1/breaking-changes/1014-better-client-id-new.md
@@ -1,4 +1,4 @@
-- `[ibc-core-host-types]` Introduce `ClientType::build_client_id` which avoids unnecessary validaiton.
+- `[ibc-core-host-types]` Introduce `ClientType::build_client_id` which avoids unnecessary validation.
   ([#1014](https://github.com/cosmos/ibc-rs/issues/1014))
 - `[ibc-core-host-types]` Optimise `ClientId::new` to avoid unnecessary validaiton and temporary
   string allocation. ([#1014](https://github.com/cosmos/ibc-rs/issues/1014))


### PR DESCRIPTION
Fixed a typo in the file 1014-better-client-id-new.md, correcting "validaiton" to "validation" for improved accuracy and readability.